### PR TITLE
(fix) GildedRose.Tests.csproj to use .NET 4.8 instead of .NET 8

### DIFF
--- a/src/GildedRose.Tests/GildedRose.Tests.csproj
+++ b/src/GildedRose.Tests/GildedRose.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -12,6 +12,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GildedRose.Console\GildedRose.Console.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Fixing GildedRose.Tests.csproj which was mistakenly updated to use .NET 8 instead of .NET 4.8.
- Also fixing project dependency to Console project.